### PR TITLE
Fix: LocalDate Parse Error 해결

### DIFF
--- a/src/main/kotlin/com/example/ggyunispring/web/DiaryController.kt
+++ b/src/main/kotlin/com/example/ggyunispring/web/DiaryController.kt
@@ -2,6 +2,7 @@ package com.example.ggyunispring.web
 
 import com.example.ggyunispring.dto.request.CreateDiaryRequestDTO
 import com.example.ggyunispring.dto.response.ResponseDTO
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
@@ -12,19 +13,17 @@ import javax.validation.Valid
 class DiaryController {
 
     @GetMapping("/{date}/list")
-    fun getDiaryList(@PathVariable("date") date: LocalDate): ResponseEntity<Any> {
-
+    fun getDiaryList(@DateTimeFormat(pattern = "yyyy-MM-dd") @PathVariable("date") date: LocalDate): ResponseEntity<Any> {
         return ResponseDTO.of(200, "test")
     }
 
     @GetMapping("/{date}/details")
-    fun getDiaryDetails(@PathVariable("date") date: LocalDate): ResponseEntity<Any> {
+    fun getDiaryDetails(@DateTimeFormat(pattern = "yyyy-MM-dd") @PathVariable("date") date: LocalDate): ResponseEntity<Any> {
         return ResponseDTO.of(200, "test")
     }
 
     @PostMapping("/create")
     fun createDiary(@Valid @RequestBody createDiaryRequestDTO: CreateDiaryRequestDTO): ResponseEntity<Any> {
-
         return ResponseDTO.of(200, "test")
     }
 }


### PR DESCRIPTION
현재 임시로 작성해놓은 `getDiaryList`, `getDiaryDetails`에서 PathVariable로 LocalDate로 받고 있는데요~ 이게 아무 설정 하지 않고 `http://localhost:8080/api/v1/diary/2021-09-30/list` 이런 형태로 받으면 LocalDate Parse Error 가 발생합니다!

그래서 `@DateTimeFormat(pattern = "yyyy-MM-dd")`를 사용해서 LocalDate 형식을 지정해서 받아오려 하고 에러를 해결하는 PR을 올립니다~! 