### PR TITLE
Refactor: 다이어리가 존재하지 않을 때 Exception -> null 반환으로 리팩터링

### DIFF
--- a/src/main/kotlin/com/example/ggyunispring/error/EntityNotFoundException.kt
+++ b/src/main/kotlin/com/example/ggyunispring/error/EntityNotFoundException.kt
@@ -1,7 +1,0 @@
-package com.example.ggyunispring.error
-
-/**
- * created by Gyunny 2021/10/04
- */
-class EntityNotFoundException() : RuntimeException() {
-}

--- a/src/main/kotlin/com/example/ggyunispring/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/ggyunispring/error/GlobalExceptionHandler.kt
@@ -14,14 +14,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 class GlobalExceptionHandler {
 
     /**
-     * Entity 가 존재하지 않을 때 204 반환
-     */
-    @ExceptionHandler(EntityNotFoundException::class)
-    fun diaryNotFoundException(): ResponseEntity<Any> {
-        return ResponseEntity.status(204).body(null)
-    }
-
-    /**
      * 구글 ID 토큰이 잘못되었을 경우
      */
     @ExceptionHandler(GoogleIdTokenException::class)

--- a/src/main/kotlin/com/example/ggyunispring/service/DiaryService.kt
+++ b/src/main/kotlin/com/example/ggyunispring/service/DiaryService.kt
@@ -7,7 +7,6 @@ import com.example.ggyunispring.domain.repository.DiaryRepository
 import com.example.ggyunispring.dto.request.CreateDiaryRequestDTO
 import com.example.ggyunispring.dto.response.CreateDiaryResponseDTO
 import com.example.ggyunispring.dto.response.DiaryResponseDTO
-import com.example.ggyunispring.error.EntityNotFoundException
 import org.modelmapper.ModelMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -49,8 +48,8 @@ class DiaryService(
     }
 
     @Transactional(readOnly = true)
-    fun findByDiaryID(localDate: LocalDate): DiaryResponseDTO {
-        val diary = diaryRepository.findByWritingDate(localDate) ?: throw EntityNotFoundException()
+    fun findByDiaryID(localDate: LocalDate): DiaryResponseDTO? {
+        val diary = diaryRepository.findByWritingDate(localDate) ?: return null
         return modelMapper.map(diary, DiaryResponseDTO::class.java);
     }
 

--- a/src/main/kotlin/com/example/ggyunispring/service/LoginService.kt
+++ b/src/main/kotlin/com/example/ggyunispring/service/LoginService.kt
@@ -62,5 +62,4 @@ class LoginService(
         return modelMapper.map(findMember, LoginResponseDTO::class.java)
     }
 
-
 }

--- a/src/main/kotlin/com/example/ggyunispring/web/DiaryController.kt
+++ b/src/main/kotlin/com/example/ggyunispring/web/DiaryController.kt
@@ -27,7 +27,7 @@ class DiaryController(
 
     @ApiOperation("다이어리 하나 상세 조회")
     @GetMapping("/{date}")
-    fun getDiaryDetails(@DateTimeFormat(pattern = "yyyy-MM-dd") @PathVariable("date") localDate: LocalDate): ResponseEntity<DiaryResponseDTO> {
+    fun getDiaryDetails(@DateTimeFormat(pattern = "yyyy-MM-dd") @PathVariable("date") localDate: LocalDate): ResponseEntity<DiaryResponseDTO?> {
         return ResponseDTO.of(200, diaryService.findByDiaryID(localDate))
     }
 


### PR DESCRIPTION
PR 전 코드에서는 다이어리를 조회했을 때 다이어리가 존재하지 않으면 `DiaryNotFoundException`을 throw 하는 코드로 했었는데요~ 

저번 PR에서 코드를 작성할 때 부터 생각했던 것인데 저희 서비스에서 다이어리가 존재하지 않을 때의 상황이 throw Exception 보다는 null 이 더 적합하다고 생각하였습니다!! 

그래서 null 반환하는 코드로 수정해보았습니다~ 

의견 편하게 말씀해주십쇼~!