### PR TITLE
Refactor: JWT Token Error Handling

### DIFF
--- a/src/main/kotlin/com/example/ggyunispring/common/enum/JWT.kt
+++ b/src/main/kotlin/com/example/ggyunispring/common/enum/JWT.kt
@@ -1,0 +1,10 @@
+package com.example.ggyunispring.common.enum
+
+/**
+ * created by Gyunny 2021/10/25
+ */
+enum class JWT(
+    val accessToken: String
+) {
+    KEY_VALUE_EMPTY("JWT HEADER EMPTY")
+}

--- a/src/main/kotlin/com/example/ggyunispring/common/jwt/JWTProvider.kt
+++ b/src/main/kotlin/com/example/ggyunispring/common/jwt/JWTProvider.kt
@@ -1,5 +1,7 @@
 package com.example.ggyunispring.common.jwt
 
+import com.example.ggyunispring.common.enum.JWT
+import com.example.ggyunispring.common.enum.JWT.KEY_VALUE_EMPTY
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
@@ -48,7 +50,7 @@ class JwtProvider {
     }
 
     fun getTokenFromHeader(request: HttpServletRequest): String {
-        val accessToken = request.getHeader(HEADER_NAME) ?: return "Empty"
+        val accessToken = request.getHeader(HEADER_NAME) ?: return KEY_VALUE_EMPTY.name
         return accessToken.replace("Bearer", "").trim()
     }
 

--- a/src/main/kotlin/com/example/ggyunispring/common/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/example/ggyunispring/common/jwt/JwtAuthenticationFilter.kt
@@ -1,5 +1,6 @@
 package com.example.ggyunispring.common.jwt
 
+import com.example.ggyunispring.common.enum.JWT.KEY_VALUE_EMPTY
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetailsService
@@ -16,20 +17,27 @@ class JwtAuthenticationFilter(
 ): GenericFilterBean() {
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         val token: String = jwtProvider.getTokenFromHeader(request as HttpServletRequest)
-        if (token == "Empty" || token == "") {
-            val httpServletResponse = response as HttpServletResponse
-            httpServletResponse.status = 401
-            httpServletResponse.contentType = "application/json"
-            httpServletResponse.characterEncoding = "utf8"
-            httpServletResponse.writer.write("비정상 메시지")
+        if (token == KEY_VALUE_EMPTY.name) {
+            abnormalMessage(response)
             return
         }
 
         if (jwtProvider.validateTokenIssuedDate(token)) {
             val authentication: Authentication = jwtProvider.getAuthentication(token, userDetailsService)
             SecurityContextHolder.getContext().authentication = authentication
+        } else {
+            abnormalMessage(response)
+            return
         }
 
         chain!!.doFilter(request, response)
+    }
+
+    private fun abnormalMessage(response: ServletResponse) {
+        val httpServletResponse = response as HttpServletResponse
+        httpServletResponse.status = 401
+        httpServletResponse.contentType = "application/json"
+        httpServletResponse.characterEncoding = "utf8"
+        httpServletResponse.writer.write("비정상 메시지")
     }
 }


### PR DESCRIPTION
#37, #40 여기 이슈에서 남긴 것을 정리해보는 PR 을 날려보았습니다 !! (이번 PR 수정한 코드는 깔끔한 거 같진 않지만,, ㅠ,ㅠ)

![1](https://user-images.githubusercontent.com/45676906/138321696-c3ec254a-daaf-464a-b88b-05a93d426b54.png)

일단 위와 같이 `HTTP Header` 에 `Authorization` Key가 존재하고 Value가 없을 때는 아래의 코드에서 에러가 잡히고 있습니다!!

<img width="473" alt="스크린샷 2021-10-25 오후 1 40 53" src="https://user-images.githubusercontent.com/45676906/138635637-12f1a1f6-7a64-44a9-a3b7-97c66cba652b.png">

<br>

![image](https://user-images.githubusercontent.com/45676906/138635687-05d99849-3cc6-45b9-b915-b661c753fb04.png)

그런데 위와 같이 `HTTP Header` 에  Key-Value가 둘 다 존재하지 않는 상황이라면 아래의 코드에서 걸리게 됩니다!

<br>

![image](https://user-images.githubusercontent.com/45676906/138635728-e8b500a8-e29a-46ac-8fa1-9644509e7e92.png)

위의 코드에서 `Exception()`을 날리고 있어서 JWT 가 헤더에 없는 상황임에도 불구하고 500 Server Error를 반환하고 있습니다! (JWT 가 존재하지 않는 상황은 500보다는 401이 더 적절하다고 생각해서 이번 PR을 올리게 되었습니다!)

처음에는 위의 에러들을 `ControllerAdvice`, `ExceptionHandler`로 잡아서 처리하려 했는데, 계속 에러가 안잡히더라구요 ㅠ 그래서 생각해보니 여기는 `Filter` 영역이고 즉, 스프링 영역 밖이니까 에러 핸들링을 하지 못하고 있구나를 깨달았습니다,, 

![스크린샷 2021-10-25 오후 1 43 58](https://user-images.githubusercontent.com/45676906/138635914-fddc0f48-4918-492e-8be8-88b933b60070.png)

그래서 위와 같이 HTTP Header에 Key-Value 둘 다 없다면 Empty 인 상황, HTTP Header에 Key만 있고 Value가 없다면 ""인 상황으로 401 에러를 Response 하도록 코드를 살짝 수정해보았습니다! 

부족한 점이 많겠지만 리뷰 부탁드립니다 ~! ㅎ,ㅎ