### PR TITLE
Feat: 다이어리 생성시 Writing Date 클라이언트로부터 받도록 수정

### DIFF
--- a/src/main/kotlin/com/example/ggyunispring/domain/entity/Diary.kt
+++ b/src/main/kotlin/com/example/ggyunispring/domain/entity/Diary.kt
@@ -2,11 +2,9 @@ package com.example.ggyunispring.domain.entity
 
 import com.example.ggyunispring.common.enum.DiaryType
 import com.example.ggyunispring.common.enum.Emotion
-import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDate
 import javax.persistence.*
 
-@EntityListeners(AuditingEntityListener::class)
 @Entity
 class Diary(
 
@@ -30,8 +28,8 @@ class Diary(
     @Enumerated(value = EnumType.STRING)
     val emotion:Emotion = Emotion.sad,
 
-    @Embedded
-    val createModifyTime: CreateModifyTime = CreateModifyTime()
+//    @Embedded
+//    val createModifyTime: CreateModifyTime = CreateModifyTime()
 ) {
 
     fun updateDiaryMemberId(memberId: Long) {

--- a/src/main/kotlin/com/example/ggyunispring/dto/request/CreateDiaryRequestDTO.kt
+++ b/src/main/kotlin/com/example/ggyunispring/dto/request/CreateDiaryRequestDTO.kt
@@ -3,6 +3,7 @@ package com.example.ggyunispring.dto.request
 import com.example.ggyunispring.common.enum.DiaryType
 import com.example.ggyunispring.common.enum.Emotion
 import org.hibernate.validator.constraints.Length
+import java.time.LocalDate
 import javax.validation.constraints.NotNull
 
 data class CreateDiaryRequestDTO(
@@ -29,6 +30,9 @@ data class CreateDiaryRequestDTO(
 
     @field:Length(min = 1, max = 100)
     val content: String,
+
+    @NotNull
+    val writingDate: LocalDate,
 
     @field:Length(min = 1)
     val latitude: String,


### PR DESCRIPTION
## 다이어리 생성시 Writing Date 클라이언트로부터 받도록 수정

다이어리를 작성할 때 이미 시간이 지난 날에도 다이어를 작성할 수 있어서 클라이언트로부터 Writing Date를 받도록 협의하였습니다~! 

예를들면 오늘이 11월 13일인데 11월 10일 다이어리를 작성하는 경우입니다~ 